### PR TITLE
using Capital N

### DIFF
--- a/ch04/myns.yaml
+++ b/ch04/myns.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-kind:       namespace
+kind:       Namespace
 metadata:
   name:     myns


### PR DESCRIPTION
this doesn't work for me with minkube when using namespace with lower "n"
minikube version: v0.27.0
kubectl version
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-05-12T04:12:12Z", GoVersion:"go1.9.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.0", GitCommit:"fc32d2f3698e36b93322a3465f63a14e9f0eaead", GitTreeState:"clean", BuildDate:"2018-03-26T16:44:10Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
