### PR TITLE
added back container name which is mandatory in ch08/cmconsumer.yaml

### DIFF
--- a/ch08/cmconsumer.yaml
+++ b/ch08/cmconsumer.yaml
@@ -11,6 +11,7 @@ spec:
     volumeMounts:
     - mountPath:  /oreilly
       name:       oreilly
+    name:         busybox      
   volumes:
   - name:
     configMap:


### PR DESCRIPTION
will error out if missing this line when kubectl apply -f this file